### PR TITLE
Expose supervisor logging functions to the public

### DIFF
--- a/supervisor.go
+++ b/supervisor.go
@@ -228,6 +228,8 @@ func New(name string, spec Spec) (s *Supervisor) {
 				name,
 			))
 		}
+	} else {
+		s.LogBadStop = spec.LogBadStop
 	}
 
 	if spec.LogFailure == nil {
@@ -261,6 +263,8 @@ func New(name string, spec Spec) (s *Supervisor) {
 				string(st),
 			))
 		}
+	} else {
+		s.LogFailure = spec.LogFailure
 	}
 
 	if spec.LogBackoff == nil {
@@ -271,6 +275,8 @@ func New(name string, spec Spec) (s *Supervisor) {
 				s.log("Exiting backoff state.")
 			}
 		}
+	} else {
+		s.LogBackoff = spec.LogBackoff
 	}
 
 	return

--- a/supervisor.go
+++ b/supervisor.go
@@ -123,6 +123,9 @@ type Spec struct {
 	FailureThreshold float64
 	FailureBackoff   time.Duration
 	Timeout          time.Duration
+	LogBadStop       BadStopLogger
+	LogFailure       FailureLogger
+	LogBackoff       BackoffLogger
 }
 
 /*
@@ -217,7 +220,7 @@ func New(name string, spec Spec) (s *Supervisor) {
 	s.resumeTimer = make(chan time.Time)
 
 	// set up the default logging handlers
-	if s.LogBadStop == nil {
+	if spec.LogBadStop == nil {
 		s.LogBadStop = func(sup *Supervisor, _ Service, name string) {
 			s.log(fmt.Sprintf(
 				"%s: Service %s failed to terminate in a timely manner",
@@ -227,7 +230,7 @@ func New(name string, spec Spec) (s *Supervisor) {
 		}
 	}
 
-	if s.LogFailure == nil {
+	if spec.LogFailure == nil {
 		s.LogFailure = func(
 			sup *Supervisor,
 			_ Service,
@@ -260,7 +263,7 @@ func New(name string, spec Spec) (s *Supervisor) {
 		}
 	}
 
-	if s.LogBackoff == nil {
+	if spec.LogBackoff == nil {
 		s.LogBackoff = func(s *Supervisor, entering bool) {
 			if entering {
 				s.log("Entering the backoff state.")

--- a/supervisor.go
+++ b/supervisor.go
@@ -19,6 +19,26 @@ const (
 type supervisorID uint32
 type serviceID uint32
 
+type (
+	// BadStopLogger is called when a service fails to properly stop
+	BadStopLogger func(*Supervisor, Service, string)
+
+	// FailureLogger is called when a service fails
+	FailureLogger func(
+		supervisor *Supervisor,
+		service Service,
+		serviceName string,
+		currentFailures float64,
+		failureThreshold float64,
+		restarting bool,
+		error interface{},
+		stacktrace []byte,
+	)
+
+	// BackoffLogger is called when the supervisor enters or exits backoff mode
+	BackoffLogger func(s *Supervisor, entering bool)
+)
+
 var currentSupervisorIDL sync.Mutex
 var currentSupervisorID uint32
 
@@ -82,16 +102,9 @@ type Supervisor struct {
 	liveness             chan struct{}
 	resumeTimer          <-chan time.Time
 
-	// The testing uses the ability to grab these individual logging functions
-	// and get inside of suture's handling at a deep level.
-	// If you ever come up with some need to get into these, submit a pull
-	// request to make them public and some smidge of justification, and
-	// I'll happily do it.
-	// But since I've now changed the signature on these once, I'm glad I
-	// didn't start with them public... :)
-	logBadStop func(*Supervisor, Service, string)
-	logFailure func(supervisor *Supervisor, service Service, serviceName string, currentFailures float64, failureThreshold float64, restarting bool, error interface{}, stacktrace []byte)
-	logBackoff func(*Supervisor, bool)
+	LogBadStop BadStopLogger
+	LogFailure FailureLogger
+	LogBackoff BackoffLogger
 
 	// avoid a dependency on github.com/thejerf/abtime by just implementing
 	// a minimal chunk.
@@ -204,26 +217,56 @@ func New(name string, spec Spec) (s *Supervisor) {
 	s.resumeTimer = make(chan time.Time)
 
 	// set up the default logging handlers
-	s.logBadStop = func(supervisor *Supervisor, service Service, name string) {
-		s.log(fmt.Sprintf("%s: Service %s failed to terminate in a timely manner", supervisor.Name, name))
-	}
-	s.logFailure = func(supervisor *Supervisor, service Service, serviceName string, failures float64, threshold float64, restarting bool, err interface{}, st []byte) {
-		var errString string
-
-		e, canError := err.(error)
-		if canError {
-			errString = e.Error()
-		} else {
-			errString = fmt.Sprintf("%#v", err)
+	if s.LogBadStop == nil {
+		s.LogBadStop = func(sup *Supervisor, _ Service, name string) {
+			s.log(fmt.Sprintf(
+				"%s: Service %s failed to terminate in a timely manner",
+				sup.Name,
+				name,
+			))
 		}
-
-		s.log(fmt.Sprintf("%s: Failed service '%s' (%f failures of %f), restarting: %#v, error: %s, stacktrace: %s", supervisor.Name, serviceName, failures, threshold, restarting, errString, string(st)))
 	}
-	s.logBackoff = func(s *Supervisor, entering bool) {
-		if entering {
-			s.log("Entering the backoff state.")
-		} else {
-			s.log("Exiting backoff state.")
+
+	if s.LogFailure == nil {
+		s.LogFailure = func(
+			sup *Supervisor,
+			_ Service,
+			svcName string,
+			f float64,
+			thresh float64,
+			restarting bool,
+			err interface{},
+			st []byte,
+		) {
+			var errString string
+
+			e, canError := err.(error)
+			if canError {
+				errString = e.Error()
+			} else {
+				errString = fmt.Sprintf("%#v", err)
+			}
+
+			s.log(fmt.Sprintf(
+				"%s: Failed service '%s' (%f failures of %f), restarting: %#v, error: %s, stacktrace: %s",
+				sup.Name,
+				svcName,
+				f,
+				thresh,
+				restarting,
+				errString,
+				string(st),
+			))
+		}
+	}
+
+	if s.LogBackoff == nil {
+		s.LogBackoff = func(s *Supervisor, entering bool) {
+			if entering {
+				s.log("Entering the backoff state.")
+			} else {
+				s.log("Exiting backoff state.")
+			}
 		}
 	}
 
@@ -268,9 +311,9 @@ func (s *Supervisor) Add(service Service) ServiceToken {
 	}
 
 	if supervisor, isSupervisor := service.(*Supervisor); isSupervisor {
-		supervisor.logBadStop = s.logBadStop
-		supervisor.logFailure = s.logFailure
-		supervisor.logBackoff = s.logBackoff
+		supervisor.LogBadStop = s.LogBadStop
+		supervisor.LogFailure = s.LogFailure
+		supervisor.LogBackoff = s.LogBackoff
 	}
 
 	s.Lock()
@@ -383,7 +426,7 @@ func (s *Supervisor) Serve() {
 			s.state = normal
 			s.Unlock()
 			s.failures = 0
-			s.logBackoff(s, false)
+			s.LogBackoff(s, false)
 			for _, id := range s.restartQueue {
 				namedService, present := s.services[id]
 				if present {
@@ -411,7 +454,7 @@ func (s *Supervisor) handleFailedService(id serviceID, err interface{}, stacktra
 		s.Lock()
 		s.state = paused
 		s.Unlock()
-		s.logBackoff(s, true)
+		s.LogBackoff(s, true)
 		s.resumeTimer = s.getAfterChan(s.failureBackoff)
 	}
 
@@ -430,12 +473,12 @@ func (s *Supervisor) handleFailedService(id serviceID, err interface{}, stacktra
 		s.Unlock()
 		if curState == normal {
 			s.runService(failedService.Service, id)
-			s.logFailure(s, failedService.Service, failedService.name, s.failures, s.failureThreshold, true, err, stacktrace)
+			s.LogFailure(s, failedService.Service, failedService.name, s.failures, s.failureThreshold, true, err, stacktrace)
 		} else {
 			// FIXME: When restarting, check that the service still
 			// exists (it may have been stopped in the meantime)
 			s.restartQueue = append(s.restartQueue, id)
-			s.logFailure(s, failedService.Service, failedService.name, s.failures, s.failureThreshold, false, err, stacktrace)
+			s.LogFailure(s, failedService.Service, failedService.name, s.failures, s.failureThreshold, false, err, stacktrace)
 		}
 	}
 }
@@ -473,7 +516,7 @@ func (s *Supervisor) removeService(id serviceID, removedChan chan supervisorMess
 			case <-successChan:
 				// Life is good!
 			case <-s.getAfterChan(s.timeout):
-				s.logBadStop(s, namedService.Service, namedService.name)
+				s.LogBadStop(s, namedService.Service, namedService.name)
 			}
 			removedChan <- serviceTerminated{id}
 		}()
@@ -502,7 +545,7 @@ func (s *Supervisor) stopSupervisor() {
 			delete(s.servicesShuttingDown, id)
 		case <-timeout:
 			for _, namedService := range s.servicesShuttingDown {
-				s.logBadStop(s, namedService.Service, namedService.name)
+				s.LogBadStop(s, namedService.Service, namedService.name)
 			}
 			return
 		}

--- a/supervisor.go
+++ b/supervisor.go
@@ -593,7 +593,6 @@ func (s *Supervisor) Services() []Service {
 
 	if s.sendControl(ls) {
 		return <-ls.c
-	} else {
-		return nil
 	}
+	return nil
 }

--- a/suture_test.go
+++ b/suture_test.go
@@ -76,8 +76,8 @@ func TestFailures(t *testing.T) {
 	defer func() {
 		// to avoid deadlocks during shutdown, we have to not try to send
 		// things out on channels while we're shutting down (this undoes the
-		// logFailure overide about 25 lines down)
-		s.logFailure = func(*Supervisor, Service, string, float64, float64, bool, interface{}, []byte) {}
+		// LogFailure overide about 25 lines down)
+		s.LogFailure = func(*Supervisor, Service, string, float64, float64, bool, interface{}, []byte) {}
 		s.Stop()
 	}()
 	s.sync()
@@ -102,7 +102,7 @@ func TestFailures(t *testing.T) {
 
 	failNotify := make(chan bool)
 	// use this to synchronize on here
-	s.logFailure = func(supervisor *Supervisor, s Service, sn string, cf float64, ft float64, r bool, error interface{}, stacktrace []byte) {
+	s.LogFailure = func(supervisor *Supervisor, s Service, sn string, cf float64, ft float64, r bool, error interface{}, stacktrace []byte) {
 		failNotify <- r
 	}
 
@@ -153,7 +153,7 @@ func TestFailures(t *testing.T) {
 
 	nowFeeder.appendTimes(oneDecayLater)
 	backingoff := make(chan bool)
-	s.logBackoff = func(s *Supervisor, backingOff bool) {
+	s.LogBackoff = func(s *Supervisor, backingOff bool) {
 		backingoff <- backingOff
 	}
 
@@ -276,8 +276,8 @@ func TestDefaultLogging(t *testing.T) {
 
 	name := serviceName(&BarelyService{})
 
-	s.logBadStop(s, service, name)
-	s.logFailure(s, service, name, 1, 1, true, errors.New("test error"), []byte{})
+	s.LogBadStop(s, service, name)
+	s.LogFailure(s, service, name, 1, 1, true, errors.New("test error"), []byte{})
 
 	s.Stop()
 }
@@ -289,8 +289,8 @@ func TestNestedSupervisors(t *testing.T) {
 	super2 := NewSimple("Nested5")
 	service := NewService("Service5")
 
-	super2.logBadStop = func(*Supervisor, Service, string) {
-		panic("Failed to copy logBadStop")
+	super2.LogBadStop = func(*Supervisor, Service, string) {
+		panic("Failed to copy LogBadStop")
 	}
 
 	super1.Add(super2)
@@ -298,7 +298,7 @@ func TestNestedSupervisors(t *testing.T) {
 
 	// test the functions got copied from super1; if this panics, it didn't
 	// get copied
-	super2.logBadStop(super2, service, "Service5")
+	super2.LogBadStop(super2, service, "Service5")
 
 	go super1.Serve()
 	super1.sync()
@@ -356,7 +356,7 @@ func TestStoppingStillWorksWithHungServices(t *testing.T) {
 		return resumeChan
 	}
 	failNotify := make(chan struct{})
-	s.logBadStop = func(supervisor *Supervisor, s Service, name string) {
+	s.LogBadStop = func(supervisor *Supervisor, s Service, name string) {
 		failNotify <- struct{}{}
 	}
 
@@ -380,7 +380,7 @@ func TestRemovingHungService(t *testing.T) {
 	s.getAfterChan = func(d time.Duration) <-chan time.Time {
 		return resumeChan
 	}
-	s.logBadStop = func(supervisor *Supervisor, s Service, name string) {
+	s.LogBadStop = func(supervisor *Supervisor, s Service, name string) {
 		failNotify <- struct{}{}
 	}
 	service := NewService("Service WillHang")
@@ -485,7 +485,7 @@ func TestFailingSupervisors(t *testing.T) {
 	}
 	failNotify := make(chan string)
 	// use this to synchronize on here
-	s1.logFailure = func(supervisor *Supervisor, s Service, name string, cf float64, ft float64, r bool, error interface{}, stacktrace []byte) {
+	s1.LogFailure = func(supervisor *Supervisor, s Service, name string, cf float64, ft float64, r bool, error interface{}, stacktrace []byte) {
 		failNotify <- fmt.Sprintf("%s", s)
 	}
 


### PR DESCRIPTION
As per the comment in the source code, I am hereby submitting a pull request and a smidge of justification for exporting `Supervisor`'s logging functions :)

I'm using suture in conjunction with [Logrus](github.com/sirupsen/logrus) and would like to put information about backoff state, retries, etc into separate Logrus fields.

All tests are passing on my machine.

Thank you very much for this nice little library!