### PR TITLE
Option to not recover panics

### DIFF
--- a/supervisor.go
+++ b/supervisor.go
@@ -108,6 +108,7 @@ type Supervisor struct {
 	control              chan supervisorMessage
 	liveness             chan struct{}
 	resumeTimer          <-chan time.Time
+	recoverPanics        bool
 
 	LogBadStop BadStopLogger
 	LogFailure FailureLogger
@@ -125,14 +126,15 @@ type Supervisor struct {
 // Spec is used to pass arguments to the New function to create a
 // supervisor. See the New function for full documentation.
 type Spec struct {
-	Log              func(string)
-	FailureDecay     float64
-	FailureThreshold float64
-	FailureBackoff   time.Duration
-	Timeout          time.Duration
-	LogBadStop       BadStopLogger
-	LogFailure       FailureLogger
-	LogBackoff       BackoffLogger
+	Log               func(string)
+	FailureDecay      float64
+	FailureThreshold  float64
+	FailureBackoff    time.Duration
+	Timeout           time.Duration
+	LogBadStop        BadStopLogger
+	LogFailure        FailureLogger
+	LogBackoff        BackoffLogger
+	PassThroughPanics bool
 }
 
 /*
@@ -176,6 +178,9 @@ failure count to zero.
 
 Timeout is how long Suture will wait for a service to properly terminate.
 
+The PassThroughPanics options can be set to let panics in services propagate
+and crash the program, should this be desirable.
+
 */
 func New(name string, spec Spec) (s *Supervisor) {
 	s = new(Supervisor)
@@ -214,6 +219,7 @@ func New(name string, spec Spec) (s *Supervisor) {
 	} else {
 		s.timeout = spec.Timeout
 	}
+	s.recoverPanics = !spec.PassThroughPanics
 
 	// overriding these allows for testing the threshold behavior
 	s.getNow = time.Now
@@ -520,14 +526,16 @@ func (s *Supervisor) handleFailedService(id serviceID, err interface{}, stacktra
 
 func (s *Supervisor) runService(service Service, id serviceID) {
 	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				buf := make([]byte, 65535, 65535)
-				written := runtime.Stack(buf, false)
-				buf = buf[:written]
-				s.fail(id, r, buf)
-			}
-		}()
+		if s.recoverPanics {
+			defer func() {
+				if r := recover(); r != nil {
+					buf := make([]byte, 65535, 65535)
+					written := runtime.Stack(buf, false)
+					buf = buf[:written]
+					s.fail(id, r, buf)
+				}
+			}()
+		}
 
 		service.Serve()
 


### PR DESCRIPTION
This adds an option "PanicsPanic" to the Spec. When set to true the behavior of capturing panics in services in disabled.

This is desirable in our use case, where an unexpected return of a service constitutes a restartable failure but a panic means we are 1) in an inconsistent state where we don't trust a restart and 2) a serious bug has happened that we want to know about, via seeing the crash and backtrace.

I hope this is noninvasive enough to mergeable, even if it is not the desirable default behavior from your side.