### PR TITLE
Don't block on Add when supervisor is done

### DIFF
--- a/supervisor.go
+++ b/supervisor.go
@@ -370,7 +370,8 @@ Add adds a service to this supervisor.
 
 If the supervisor is currently running, the service will be started
 immediately. If the supervisor is not currently running, the service
-will be started when the supervisor is.
+will be started when the supervisor is. If the supervisor was already stopped,
+this is a no-op returning an empty service-token.
 
 The returned ServiceID may be passed to the Remove method of the Supervisor
 to terminate the service.
@@ -408,6 +409,9 @@ func (s *Supervisor) Add(service Service) ServiceToken {
 
 	response := make(chan serviceID)
 	s.control <- addService{service, serviceName(service), response}
+	if !s.sendControl(addService{service, serviceName(service), response}) {
+		return ServiceToken{}
+	}
 	return ServiceToken{uint64(s.id)<<32 | uint64(<-response)}
 }
 

--- a/suture_test.go
+++ b/suture_test.go
@@ -716,6 +716,29 @@ func TestEverMultistarted(t *testing.T) {
 	}
 }
 
+func TestAddAfterStopping(t *testing.T) {
+	// t.Parallel()
+
+	s := NewSimple("main")
+
+	service := NewService("A1")
+	addDone := make(chan struct{})
+
+	s.ServeBackground()
+	s.Stop()
+
+	go func() {
+		s.Add(service)
+		close(addDone)
+	}()
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for Add to return")
+	case <-addDone:
+	}
+}
+
 // A test service that can be induced to fail, panic, or hang on demand.
 func NewService(name string) *FailableService {
 	return &FailableService{name, make(chan bool), make(chan int),

--- a/v4/supervisor.go
+++ b/v4/supervisor.go
@@ -235,8 +235,9 @@ func (s *Supervisor) GetSupervisor() *Supervisor {
 Add adds a service to this supervisor.
 
 If the supervisor is currently running, the service will be started
-immediately. If the supervisor is not currently running, the service
-will be started when the supervisor is.
+immediately. If the supervisor has not been started yet, the service
+will be started when the supervisor is. If the supervisor was already stopped,
+this is a no-op returning an empty service-token.
 
 The returned ServiceID may be passed to the Remove method of the Supervisor
 to terminate the service.
@@ -276,7 +277,9 @@ func (s *Supervisor) Add(service Service) ServiceToken {
 	s.m.Unlock()
 
 	response := make(chan serviceID)
-	s.control <- addService{service, serviceName(service), response}
+	if !s.sendControl(addService{service, serviceName(service), response}) {
+		return ServiceToken{}
+	}
 	return ServiceToken{uint64(s.id)<<32 | uint64(<-response)}
 }
 


### PR DESCRIPTION
Fixes #41 

I filed the PR against the jcontext branch including fixes for pre-v4, i.e. can easily be copied/cherry-picked to master.