### PR TITLE
jcontext: fix regression introduced in #42 & various

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,6 @@ go:
   - 1.9
   - 1.11
   - 1.13
+  - 1.15
   - tip
+script: go test -timeout 20s ${gobuild_args} ./...

--- a/supervisor.go
+++ b/supervisor.go
@@ -408,7 +408,6 @@ func (s *Supervisor) Add(service Service) ServiceToken {
 	s.Unlock()
 
 	response := make(chan serviceID)
-	s.control <- addService{service, serviceName(service), response}
 	if !s.sendControl(addService{service, serviceName(service), response}) {
 		return ServiceToken{}
 	}

--- a/v4/supervisor.go
+++ b/v4/supervisor.go
@@ -698,7 +698,7 @@ terminate. A timeout value of 0 means to wait forever.
 
 If a nil error is returned from this function, then the service was
 terminated normally. If either the supervisor terminates or the timeout
-passes, Err is returned. (If this isn't even the right supervisor
+passes, ErrTimeout is returned. (If this isn't even the right supervisor
 ErrWrongSupervisor is returned.)
 */
 func (s *Supervisor) RemoveAndWait(id ServiceToken, timeout time.Duration) error {


### PR DESCRIPTION
Mainly this fixes my oversight in #42 which luckily caused test failures (where I copied over the changes from v4 without deleting the old code...) - sorry about that.

While at it I fixed a remaining review nit (https://github.com/thejerf/suture/pull/43#discussion_r502948116), added test timeouts to the travis config and finally added go1.15 for good measure. The resulting error is much more clear than the current state where just the global travis timeout kicks in if someone introduces a deadlock in tests like I did here.

It would also be worth considering adding travis runs to the PR checks, to catch errors like this before merging.