### PR TITLE
v4: Return channel passing error on ServeBackground

### DIFF
--- a/v4/supervisor.go
+++ b/v4/supervisor.go
@@ -290,9 +290,14 @@ func (s *Supervisor) Add(service Service) ServiceToken {
 
 // ServeBackground starts running a supervisor in its own goroutine. When
 // this method returns, the supervisor is guaranteed to be in a running state.
-func (s *Supervisor) ServeBackground(ctx context.Context) {
-	go s.Serve(ctx)
+// The returned one-buffered channel receives the error returned by .Serve.
+func (s *Supervisor) ServeBackground(ctx context.Context) <-chan error {
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- s.Serve(ctx)
+	}()
 	s.sync()
+	return errChan
 }
 
 /*


### PR DESCRIPTION
The purpose of this change is to replace the following (unsafe) pattern:

```
	errChan := make(chan error)
	go func() {
		errChan <- s.Serve()
	}()
	// Add things to supervisor s
	err := <-errChan
	// React to error and do cleanup
```

It addresses the same need as the very broken attempt #50 (sorry again).