### PR TITLE
v4: Make ServiceToken a two-element struct

### DIFF
--- a/v4/suture_test.go
+++ b/v4/suture_test.go
@@ -444,11 +444,12 @@ func TestRemoveService(t *testing.T) {
 	}
 	<-service.stop
 
-	err = s.Remove(ServiceToken{id.id + (1 << 32)})
+	wrongSup := ServiceToken{supervisor: id.supervisor + 1, service: id.service}
+	err = s.Remove(wrongSup)
 	if err != ErrWrongSupervisor {
 		t.Fatal("Did not detect that the ServiceToken was wrong")
 	}
-	err = s.RemoveAndWait(ServiceToken{id.id + (1 << 32)}, time.Second)
+	err = s.RemoveAndWait(wrongSup, time.Second)
 	if err != ErrWrongSupervisor {
 		t.Fatal("Did not detect that the ServiceToken was wrong")
 	}


### PR DESCRIPTION
No more bit fiddling to get the supervisor and service ids out.