### PR TITLE
feat: add EventStart type and send on hook when starting service

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,4 @@
 /*
-
 Package suture provides Erlang-like supervisor trees.
 
 This implements Erlang-esque supervisor trees, as adapted for Go. This
@@ -16,13 +15,13 @@ trying to fall apart.
 
 Why use Suture?
 
- * You want to write bullet-resistant services that will remain available
-   despite unforeseen failure.
- * You need the code to be smart enough not to consume 100% of the CPU
-   restarting things.
- * You want to easily compose multiple such services in one program.
- * You want the Erlang programmers to stop lording their supervision
-   trees over you.
+  - You want to write bullet-resistant services that will remain available
+    despite unforeseen failure.
+  - You need the code to be smart enough not to consume 100% of the CPU
+    restarting things.
+  - You want to easily compose multiple such services in one program.
+  - You want the Erlang programmers to stop lording their supervision
+    trees over you.
 
 Suture has 100% test coverage, and is golint clean. This doesn't prove it
 free of bugs, but it shows I care.
@@ -30,7 +29,7 @@ free of bugs, but it shows I care.
 A blog post describing the design decisions is available at
 http://www.jerf.org/iri/post/2930 .
 
-Using Suture
+# Using Suture
 
 To idiomatically use Suture, create a Supervisor which is your top level
 "application" supervisor. This will often occur in your program's "main"
@@ -54,6 +53,5 @@ you've defined.
 
 See the Example for an example, using a simple service that serves out
 incrementing integers.
-
 */
 package suture

--- a/service.go
+++ b/service.go
@@ -3,7 +3,7 @@ package suture
 /*
 Service is the interface that describes a service to a Supervisor.
 
-Serve Method
+# Serve Method
 
 The Serve method is called by a Supervisor to start the service.
 The service should execute within the goroutine that this is
@@ -14,7 +14,7 @@ A Serve method SHOULD do as much cleanup of the state as possible,
 to prevent any corruption in the previous state from crashing the
 service again.
 
-Stop Method
+# Stop Method
 
 This method is used by the supervisor to stop the service. Calling this
 directly on a Service given to a Supervisor will simply result in the
@@ -48,7 +48,7 @@ properly stopped in the future. Until the service is fully stopped,
 both the service and the spawned goroutine trying to stop it will be
 "leaked".
 
-Stringer Interface
+# Stringer Interface
 
 When a Service is added to a Supervisor, the Supervisor will create a
 string representation of that service used for logging.
@@ -58,12 +58,11 @@ If you implement the fmt.Stringer interface, that will be used.
 If you do not implement the fmt.Stringer interface, a default
 fmt.Sprintf("%#v") will be used.
 
-Optional Interface
+# Optional Interface
 
 Services may optionally implement IsCompletable, which allows a service
 to indicate to a supervisor that it does not need to be restarted if
 it has terminated.
-
 */
 type Service interface {
 	Serve()
@@ -71,7 +70,6 @@ type Service interface {
 }
 
 /*
-
 IsCompletable is an optionally-implementable interface that allows a service
 to report to a supervisor that it does not need to be restarted because it
 has terminated normally. When a Service is going to be restarted, the
@@ -80,7 +78,6 @@ service is removed from the supervisor instead of restarted.
 
 This is only executed when the service is not running because it has
 terminated, and has not yet been restarted.
-
 */
 type IsCompletable interface {
 	Complete() bool

--- a/supervisor.go
+++ b/supervisor.go
@@ -123,14 +123,13 @@ func.
 Calling ServeBackground will CORRECTLY start the supervisor running in a
 new goroutine. You do not want to just:
 
-  go supervisor.Serve()
+	go supervisor.Serve()
 
 because that will briefly create a race condition as it starts up, if you
 try to .Add() services immediately afterward.
 
 The various Log function should only be modified while the Supervisor is
 not running, to prevent race conditions.
-
 */
 type Supervisor struct {
 	Name string
@@ -185,7 +184,6 @@ type Spec struct {
 }
 
 /*
-
 New is the full constructor function for a supervisor.
 
 The name is a friendly human name for the supervisor, used in logging. Suture
@@ -193,21 +191,21 @@ does not care if this is unique, but it is good for your sanity if it is.
 
 If not set, the following values are used:
 
- * Log:               A function is created that uses log.Print.
- * FailureDecay:      30 seconds
- * FailureThreshold:  5 failures
- * FailureBackoff:    15 seconds
- * Timeout:           10 seconds
- * BackoffJitter:     DefaultJitter
+  - Log:               A function is created that uses log.Print.
+  - FailureDecay:      30 seconds
+  - FailureThreshold:  5 failures
+  - FailureBackoff:    15 seconds
+  - Timeout:           10 seconds
+  - BackoffJitter:     DefaultJitter
 
 The Log function will be called when errors occur. Suture will log the
 following:
 
- * When a service has failed, with a descriptive message about the
-   current backoff status, and whether it was immediately restarted
- * When the supervisor has gone into its backoff mode, and when it
-   exits it
- * When a service fails to stop
+  - When a service has failed, with a descriptive message about the
+    current backoff status, and whether it was immediately restarted
+  - When the supervisor has gone into its backoff mode, and when it
+    exits it
+  - When a service fails to stop
 
 The failureRate, failureThreshold, and failureBackoff controls how failures
 are handled, in order to avoid the supervisor failure case where the
@@ -228,7 +226,6 @@ Timeout is how long Suture will wait for a service to properly terminate.
 
 The PassThroughPanics options can be set to let panics in services propagate
 and crash the program, should this be desirable.
-
 */
 func New(name string, spec Spec) (s *Supervisor) {
 	s = new(Supervisor)
@@ -381,7 +378,6 @@ supervisor being added will copy the Log function from the Supervisor it
 is being added to. This allows factoring out providing a Supervisor
 from its logging. This unconditionally overwrites the child Supervisor's
 logging functions.
-
 */
 func (s *Supervisor) Add(service Service) ServiceToken {
 	if s == nil {
@@ -816,10 +812,8 @@ func (s *Supervisor) RemoveAndWait(id ServiceToken, timeout time.Duration) error
 }
 
 /*
-
 Services returns a []Service containing a snapshot of the services this
 Supervisor is managing.
-
 */
 func (s *Supervisor) Services() []Service {
 	ls := listServices{make(chan []Service)}

--- a/v4/doc.go
+++ b/v4/doc.go
@@ -1,5 +1,4 @@
 /*
-
 Package suture provides Erlang-like supervisor trees.
 
 This implements Erlang-esque supervisor trees, as adapted for Go. This
@@ -11,13 +10,13 @@ trying to fall apart.
 
 Why use Suture?
 
- * You want to write bullet-resistant services that will remain available
-   despite unforeseen failure.
- * You need the code to be smart enough not to consume 100% of the CPU
-   restarting things.
- * You want to easily compose multiple such services in one program.
- * You want the Erlang programmers to stop lording their supervision
-   trees over you.
+  - You want to write bullet-resistant services that will remain available
+    despite unforeseen failure.
+  - You need the code to be smart enough not to consume 100% of the CPU
+    restarting things.
+  - You want to easily compose multiple such services in one program.
+  - You want the Erlang programmers to stop lording their supervision
+    trees over you.
 
 Suture has 100% test coverage, and is golint clean. This doesn't prove it
 free of bugs, but it shows I care.
@@ -25,7 +24,7 @@ free of bugs, but it shows I care.
 A blog post describing the design decisions is available at
 http://www.jerf.org/iri/post/2930 .
 
-Using Suture
+# Using Suture
 
 To idiomatically use Suture, create a Supervisor which is your top level
 "application" supervisor. This will often occur in your program's "main"
@@ -49,6 +48,5 @@ you've defined.
 
 See the Example for an example, using a simple service that serves out
 incrementing integers.
-
 */
 package suture

--- a/v4/errors_after_13.go
+++ b/v4/errors_after_13.go
@@ -13,7 +13,7 @@ func isErr(err error, target error) bool {
 // error will count as an ErrDoNotRestart.
 var ErrDoNotRestart = errors.New("service should not be restarted")
 
-// ErrTerminateSupervisorTree can can be returned by a service to terminate the
+// ErrTerminateSupervisorTree can be returned by a service to terminate the
 // entire supervision tree above it as well. Any error that will compare
 // with errors.Is to be ErrTerminateSupervisorTree will count as an
 // ErrTerminateSupervisorTree.

--- a/v4/errors_after_13.go
+++ b/v4/errors_after_13.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 package suture

--- a/v4/errors_before_13.go
+++ b/v4/errors_before_13.go
@@ -1,3 +1,4 @@
+//go:build !go1.13
 // +build !go1.13
 
 package suture

--- a/v4/events.go
+++ b/v4/events.go
@@ -32,6 +32,7 @@ const (
 	EventTypeServiceTerminate
 	EventTypeBackoff
 	EventTypeResume
+	EventTypeStart
 )
 
 type EventStopTimeout struct {
@@ -182,5 +183,26 @@ func (e EventResume) String() string {
 func (e EventResume) Map() map[string]interface{} {
 	return map[string]interface{}{
 		"supervisor_name": e.SupervisorName,
+	}
+}
+
+type EventStart struct {
+	Supervisor     *Supervisor `json:"-"`
+	SupervisorName string      `json:"supervisor_name"`
+	ServiceName    string      `json:"service_name"`
+}
+
+func (e EventStart) Type() EventType {
+	return EventTypeStart
+}
+
+func (e EventStart) String() string {
+	return fmt.Sprintf("%s: Starting service", e.ServiceName)
+}
+
+func (e EventStart) Map() map[string]interface{} {
+	return map[string]interface{}{
+		"supervisor_name": e.SupervisorName,
+		"service_name":    e.ServiceName,
 	}
 }

--- a/v4/service.go
+++ b/v4/service.go
@@ -7,7 +7,7 @@ import (
 /*
 Service is the interface that describes a service to a Supervisor.
 
-Serve Method
+# Serve Method
 
 The Serve method is called by a Supervisor to start the service.
 The service should execute within the goroutine that this is
@@ -55,7 +55,7 @@ properly stopped in the future. Until the service is fully stopped,
 both the service and the spawned goroutine trying to stop it will be
 "leaked".
 
-Stringer Interface
+# Stringer Interface
 
 When a Service is added to a Supervisor, the Supervisor will create a
 string representation of that service used for logging.
@@ -64,7 +64,6 @@ If you implement the fmt.Stringer interface, that will be used.
 
 If you do not implement the fmt.Stringer interface, a default
 fmt.Sprintf("%#v") will be used.
-
 */
 type Service interface {
 	Serve(ctx context.Context) error

--- a/v4/supervisor.go
+++ b/v4/supervisor.go
@@ -51,11 +51,10 @@ program will be to call one of the Serve methods.
 Calling ServeBackground will CORRECTLY start the supervisor running in a
 new goroutine. It is risky to directly run
 
-  go supervisor.Serve()
+	go supervisor.Serve()
 
 because that will briefly create a race condition as it starts up, if you
 try to .Add() services immediately afterward.
-
 */
 type Supervisor struct {
 	Name string
@@ -98,7 +97,6 @@ type Supervisor struct {
 }
 
 /*
-
 New is the full constructor function for a supervisor.
 
 The name is a friendly human name for the supervisor, used in logging. Suture
@@ -106,21 +104,21 @@ does not care if this is unique, but it is good for your sanity if it is.
 
 If not set, the following values are used:
 
- * EventHook:         A function is created that uses log.Print.
- * FailureDecay:      30 seconds
- * FailureThreshold:  5 failures
- * FailureBackoff:    15 seconds
- * Timeout:           10 seconds
- * BackoffJitter:     DefaultJitter
+  - EventHook:         A function is created that uses log.Print.
+  - FailureDecay:      30 seconds
+  - FailureThreshold:  5 failures
+  - FailureBackoff:    15 seconds
+  - Timeout:           10 seconds
+  - BackoffJitter:     DefaultJitter
 
 The EventHook function will be called when errors occur. Suture will log the
 following:
 
- * When a service has failed, with a descriptive message about the
-   current backoff status, and whether it was immediately restarted
- * When the supervisor has gone into its backoff mode, and when it
-   exits it
- * When a service fails to stop
+  - When a service has failed, with a descriptive message about the
+    current backoff status, and whether it was immediately restarted
+  - When the supervisor has gone into its backoff mode, and when it
+    exits it
+  - When a service fails to stop
 
 The failureRate, failureThreshold, and failureBackoff controls how failures
 are handled, in order to avoid the supervisor failure case where the
@@ -146,7 +144,6 @@ DontPropagateTermination indicates whether this supervisor tree will
 propagate a ErrTerminateTree if a child process returns it. If false,
 this supervisor will itself return an error that will terminate its
 parent. If true, it will merely return ErrDoNotRestart. false by default.
-
 */
 func New(name string, spec Spec) *Supervisor {
 	spec.configureDefaults(name)
@@ -255,7 +252,6 @@ supervisor being added will copy the EventHook function from the Supervisor it
 is being added to. This allows factoring out providing a Supervisor
 from its logging. This unconditionally overwrites the child Supervisor's
 logging functions.
-
 */
 func (s *Supervisor) Add(service Service) ServiceToken {
 	if s == nil {
@@ -759,10 +755,8 @@ func (s *Supervisor) RemoveAndWait(id ServiceToken, timeout time.Duration) error
 }
 
 /*
-
 Services returns a []Service containing a snapshot of the services this
 Supervisor is managing.
-
 */
 func (s *Supervisor) Services() []Service {
 	ls := listServices{make(chan []Service)}


### PR DESCRIPTION
In order to get notifications when the services are started, add a `EventStart` and add it to when starting to run the service.