### PR TITLE
EventStopTimeout: use reflection for type printing

### DIFF
--- a/v4/events.go
+++ b/v4/events.go
@@ -2,6 +2,7 @@ package suture
 
 import (
 	"fmt"
+	"reflect"
 )
 
 // Event defines the interface implemented by all events Suture will
@@ -46,10 +47,16 @@ func (e EventStopTimeout) Type() EventType {
 }
 
 func (e EventStopTimeout) String() string {
+	var serviceName string
+	if stringer, ok := e.Service.(fmt.Stringer); ok {
+		serviceName = stringer.String()
+	} else {
+		serviceName = reflect.TypeOf(e.Service).String()
+	}
 	return fmt.Sprintf(
-		"%s: Service %s failed to terminate in a timely manner",
+		"%s: Service '%s' failed to terminate in a timely manner",
 		e.Supervisor,
-		e.Service,
+		serviceName,
 	)
 }
 

--- a/v4/events_test.go
+++ b/v4/events_test.go
@@ -1,0 +1,46 @@
+package suture
+
+import (
+	"context"
+	"testing"
+)
+
+var _ Service = (*ServiceWithSecret)(nil)
+
+type ServiceWithSecret struct {
+	secret string
+}
+
+func (s *ServiceWithSecret) Serve(context.Context) error {
+	return nil
+}
+
+func TestEventStopTimeout_String(t *testing.T) {
+	tests := map[string]struct {
+		Supervisor *Supervisor
+		Service    Service
+		want       string
+	}{
+		"service doesn't implement fmt.Stringer": {
+			Supervisor: &Supervisor{Name: "test"},
+			Service:    &ServiceWithSecret{secret: "MySecret"},
+			want:       "test: Service '*suture.ServiceWithSecret' failed to terminate in a timely manner",
+		},
+		"service implements fmt.Stringer": {
+			Supervisor: &Supervisor{Name: "test"},
+			Service:    NewService("named"),
+			want:       "test: Service 'named' failed to terminate in a timely manner",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			e := EventStopTimeout{
+				Supervisor: tt.Supervisor,
+				Service:    tt.Service,
+			}
+			if got := e.String(); got != tt.want {
+				t.Errorf("EventStopTimeout.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This has some security implications: if the service doesn't implement fmt.Stringer, the full struct will be printed.
Those structs can contain confidential values and we don't want to log those.

@thejerf PTAL