### PR TITLE
fix: correct typos in comments and test messages

### DIFF
--- a/suture_test.go
+++ b/suture_test.go
@@ -76,7 +76,7 @@ func TestFailures(t *testing.T) {
 	defer func() {
 		// to avoid deadlocks during shutdown, we have to not try to send
 		// things out on channels while we're shutting down (this undoes the
-		// LogFailure overide about 25 lines down)
+		// LogFailure override about 25 lines down)
 		s.LogFailure = func(*Supervisor, Service, string, float64, float64, bool, interface{}, []byte) {}
 		s.Stop()
 	}()
@@ -318,7 +318,7 @@ func TestStoppingSupervisorStopsServices(t *testing.T) {
 	<-service.stop
 
 	if s.sendControl(syncSupervisor{}) {
-		t.Fatal("supervisor is shut down, should be returning fals for sendControl")
+		t.Fatal("supervisor is shut down, should be returning false for sendControl")
 	}
 	if s.Services() != nil {
 		t.Fatal("Non-running supervisor is returning services list")

--- a/v4/supervisor.go
+++ b/v4/supervisor.go
@@ -315,7 +315,7 @@ func (s *Supervisor) Serve(ctx context.Context) error {
 		panic("Can't serve with a nil *suture.Supervisor")
 	}
 	// Take a separate cancellation function so this tree can be
-	// indepedently cancelled.
+	// independently cancelled.
 	ctx, myCancel := context.WithCancel(ctx)
 	s.ctxMutex.Lock()
 	s.ctx = ctx

--- a/v4/suture_test.go
+++ b/v4/suture_test.go
@@ -81,7 +81,7 @@ func TestFailures(t *testing.T) {
 	defer func() {
 		// to avoid deadlocks during shutdown, we have to not try to send
 		// things out on channels while we're shutting down (this undoes the
-		// LogFailure overide about 25 lines down)
+		// LogFailure override about 25 lines down)
 		s.spec.EventHook = func(Event) {}
 		cancel()
 	}()


### PR DESCRIPTION
Fix four typos found by codespell in `.go` files:

- `overide` → `override` in `suture_test.go` and `v4/suture_test.go` (comment)
- `fals` → `false` in `suture_test.go` (test error message)
- `indepedently` → `independently` in `v4/supervisor.go` (comment)